### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Shopify APIと連携するMCPサーバーです。このサーバーを使用することで、Claude DesktopからShopifyの商品情報を取得・操作することができます。
 
+<a href="https://glama.ai/mcp/servers/zfff0mhppb">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/zfff0mhppb/badge" alt="Shopify Python Server MCP server" />
+</a>
+
 ## 機能
 
 ### ツール


### PR DESCRIPTION
This PR adds a badge for the [Shopify Python MCP Server](https://glama.ai/mcp/servers/zfff0mhppb) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/zfff0mhppb">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/zfff0mhppb/badge" alt="Shopify Python Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.